### PR TITLE
Remove donate button from page header

### DIFF
--- a/frontend/src/Components/Page/Header/PageHeader.js
+++ b/frontend/src/Components/Page/Header/PageHeader.js
@@ -75,14 +75,6 @@ class PageHeader extends Component {
         <ArtistSearchInputConnector />
 
         <div className={styles.right}>
-          <IconButton
-            className={styles.donate}
-            name={icons.HEART}
-            aria-label="Donate"
-            to="https://lidarr.audio/donate"
-            size={14}
-            title={translate('Donate')}
-          />
 
           <IconButton
             className={styles.translation}


### PR DESCRIPTION
The donate button was removed to streamline the page header design and reduce distractions. Users can still access donation options via other parts of the application.

#### Issues Fixed or Closed by this PR

* Fixes #1 