### PR TITLE
Remove translation suggestion button from PageHeader

### DIFF
--- a/frontend/src/Components/Page/Header/PageHeader.js
+++ b/frontend/src/Components/Page/Header/PageHeader.js
@@ -75,15 +75,6 @@ class PageHeader extends Component {
         <ArtistSearchInputConnector />
 
         <div className={styles.right}>
-
-          <IconButton
-            className={styles.translation}
-            title={translate('SuggestTranslationChange')}
-            name={icons.TRANSLATE}
-            to="https://translate.servarr.com/projects/servarr/lidarr/"
-            size={24}
-          />
-
           <PageHeaderActionsMenu
             onKeyboardShortcutsPress={this.onOpenKeyboardShortcutsModal}
           />


### PR DESCRIPTION
The translation suggestion button was removed to streamline the header and reduce visual clutter (see #8)

#### Database Migration
NO

#### Description
See issue #8 

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #8 