### PR TITLE
Remove unused MenuButton component from PageHeaderActionsMenu

### DIFF
--- a/frontend/src/Components/Page/Header/PageHeaderActionsMenu.tsx
+++ b/frontend/src/Components/Page/Header/PageHeaderActionsMenu.tsx
@@ -38,9 +38,6 @@ function PageHeaderActionsMenu(props: PageHeaderActionsMenuProps) {
   return (
     <div>
       <Menu alignMenu={align.RIGHT}>
-        <MenuButton className={styles.menuButton} aria-label="Menu Button">
-          <Icon name={icons.INTERACTIVE} title={translate('Menu')} />
-        </MenuButton>
 
         <MenuContent>
           <MenuItem onPress={onKeyboardShortcutsPress}>


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The MenuButton element and associated icon were removed as they were no longer needed. This change simplifies the component structure and eliminates redundant code.


#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #16 